### PR TITLE
Support python 2.6

### DIFF
--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -22,7 +22,7 @@ def install_mp_handler(logger=None):
 
     for i, orig_handler in enumerate(list(logger.handlers)):
         handler = MultiProcessingHandler(
-            'mp-handler-{}'.format(i), sub_handler=orig_handler)
+            'mp-handler-{0}'.format(i), sub_handler=orig_handler)
 
         logger.removeHandler(orig_handler)
         logger.addHandler(handler)


### PR DESCRIPTION
@jruere, I'm using your library in a project of mine, and this string format:
         `MultiProcessingHandler('mp-handler-{}'.format(i), sub_handler=orig_handler)`

breaks my build for python 2.6.  This is because the indices have to be specified in calls to format() for python 2.6.  This PR makes that change. 

I'm not sure if there is any other reason why this library wouldn't work in python 2.6 (though I did see its only tested on 2.7 and 3.4) -- if there is then disregard this PR. 

Thanks!
  