### PR TITLE
Close queue and join_thread on handler close

### DIFF
--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -90,3 +90,5 @@ class MultiProcessingHandler(logging.Handler):
     def close(self):
         self.sub_handler.close()
         logging.Handler.close(self)
+        self.queue.close()
+        self.queue.join_thread()


### PR DESCRIPTION
Hi there!

TL;DR: This PR closes the queue and joins to ensure it has been flushed on application shutdown. I *think* it is safe. The tests pass, it works for me, and it seems "correct", but I'm not 100% sure it will work for everyone. I'd be interested to know your thoughts.

First a bit of background - I'm using multiprocessing-logging in an application that can be invoked as a running service or a command line application.

In the case of the service, everything works really well. However in the command line application, the last couple of logging calls often aren't emitted before the application exits. This can result in a random exception, but usually the messages just disappear. I suspect the same thing is happening in the service case, but being masked by slower termination, and the fact that it's not as noticeable if a random log line is missed as opposed to the final output of your terminal app.

The fix, in my case, is the contents of this pull request. When close() is invoked on the handler, it closes the queue and then joins it, waiting for it to be flushed (https://docs.python.org/3.5/library/multiprocessing.html#multiprocessing.Queue.close). The question, is whether this is safe for everyone's use cases.

The immediate scenario that comes to mine is if thread A calls Queue.close(), and thread B subsequently calls put(). According to the docs, Queue.close() indicates that "no more data will be put on this queue by the current process". Thus, it seems fair to assume it will not affect other processes.

Also, close() is supposed to only be called by logging.shutdown(), which states "This should be called at application exit and no further use of the logging system should be made after this call."
So it would be incorrect for a put to be made to the queue after close().