### PR TITLE
Document use with multiprocessing.Pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,12 @@ and that's it.
 
 ## With multiprocessing.Pool
 
-When using a Pool, the process workers instantiated by the Pool will not initialize multiprocessing-logging handlers automatically. Currently, there's no solution for this.
+When using a Pool, make sure `install_mp_handler` is called before the Pool is instantiated, for example:
+
+    import logging
+    from multiprocessing import Pool
+    from multiprocessing_logging import install_mp_handler
+    
+    loggig.basicConfig(...)
+    install_mp_handler()
+    pool = Pool(...)


### PR DESCRIPTION
Very belatedly following up on [this comment](https://github.com/jruere/multiprocessing-logging/issues/1#issuecomment-270689574), the problems I was experiencing are because `logging` [likes](https://github.com/python/cpython/blob/e64a47b37d0c592fd162b2f51e79ecfd046b45ec/Lib/logging/__init__.py#L1676) [calling](https://github.com/python/cpython/blob/e64a47b37d0c592fd162b2f51e79ecfd046b45ec/Lib/logging/__init__.py#L682) .close() [a lot](https://github.com/python/cpython/blob/e64a47b37d0c592fd162b2f51e79ecfd046b45ec/Lib/logging/__init__.py#L1676) and that confused one of my [handlers](https://github.com/Simplistix/mailinglogger/blob/master/mailinglogger/SummarisingLogger.py#L87).

So, here's the docs of what works for me :-)