### PR TITLE
Allow underlying queue to be customized

### DIFF
--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -16,7 +16,7 @@ except ImportError:
     BrokenPipeError = OSError
 
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 
 def install_mp_handler(logger=None):
@@ -52,7 +52,14 @@ def uninstall_mp_handler(logger=None):
 
 class MultiProcessingHandler(logging.Handler):
 
-    def __init__(self, name, sub_handler=None):
+    def __init__(self, name, sub_handler=None, queue_factory=None):
+        """
+        :param name: The name of this handler
+        :param sub_handler: The handler to foward events to. If None, use a new logging.SteamHandler
+        :param queue_factory: Used to modify the underlying queue used. Provide a zero argument callable that returns an
+            object matching the interface of multiprocessing.Queue. If None, multiprocessing.Queue is used as the
+            underlying queue.
+        """
         super(MultiProcessingHandler, self).__init__()
 
         if sub_handler is None:
@@ -63,7 +70,11 @@ class MultiProcessingHandler(logging.Handler):
         self.setFormatter(self.sub_handler.formatter)
         self.filters = self.sub_handler.filters
 
-        self.queue = multiprocessing.Queue(-1)
+        if queue_factory is None:
+            self.queue = multiprocessing.Queue(-1)
+        else:
+            self.queue = queue_factory()
+
         self._is_closed = False
         # The thread handles receiving records asynchronously.
         self._receive_thread = threading.Thread(target=self._receive, name=name)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'README.m
 
 setup(
     name='multiprocessing-logging',
-    version='0.3.1',
+    version='0.4.0',
     description='Logger for multiprocessing applications',
     long_description_content_type="text/markdown",
     long_description=io.open(readme_file, 'rt', encoding='utf-8').read(),


### PR DESCRIPTION
I've got a use case where I have I'd like to inject a custom queue type that behaves closely to multiprocessing.Queue. This allows the user to supply a factory function to create new queue instances.