### PR TITLE
Compatibility with ProcessPoolExecutor

### DIFF
--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -64,7 +64,7 @@ class MultiProcessingHandler(logging.Handler):
         self.setFormatter(self.sub_handler.formatter)
         self.filters = self.sub_handler.filters
 
-        self.queue = multiprocessing.Queue(-1)
+        self.queue = multiprocessing.Manager().Queue(-1)
         self._is_closed = False
         # The thread handles receiving records asynchronously.
         self._receive_thread = threading.Thread(target=self._receive, name=name)
@@ -97,8 +97,7 @@ class MultiProcessingHandler(logging.Handler):
             except:
                 traceback.print_exc(file=sys.stderr)
 
-        self.queue.close()
-        self.queue.join_thread()
+        self.queue.join()
 
     def _send(self, s):
         self.queue.put_nowait(s)

--- a/multiprocessing_logging.py
+++ b/multiprocessing_logging.py
@@ -97,8 +97,6 @@ class MultiProcessingHandler(logging.Handler):
             except:
                 traceback.print_exc(file=sys.stderr)
 
-        self.queue.join()
-
     def _send(self, s):
         self.queue.put_nowait(s)
 


### PR DESCRIPTION
According to the python cookbook
(https://docs.python.org/3.8/howto/logging-cookbook.html#using-concurrent-futures-processpoolexecutor)
multiprocessing.Manager().Queue() should be use with
ProcessPoolExecutor.
If not there is a change of deadlock
(https://docs.python.org/3.8/library/multiprocessing.html#pipes-and-queues).

This change should not break existing code as
multiprocessing.Manager().Queue() can be used as drop-in replacement for
the regular multiprocessing.Queue()